### PR TITLE
Add path element to authority base url request to enable custom servers

### DIFF
--- a/pkg/oidc/discovery.go
+++ b/pkg/oidc/discovery.go
@@ -18,7 +18,7 @@ func GetSchemeAndHost(urlString string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host), nil
+	return fmt.Sprintf("%s://%s%s", parsed.Scheme, parsed.Host, parsed.Path), nil
 }
 
 


### PR DESCRIPTION
As some OAuth providers allows to create custom OAuth server instances on the same hostname with application id in url path we should allow to discover them and all required endpoints.